### PR TITLE
Small issue with end_table_cell: th instead of td

### DIFF
--- a/lib/Markdent/Role/HTMLStream.pm
+++ b/lib/Markdent/Role/HTMLStream.pm
@@ -225,7 +225,7 @@ sub start_table_cell {
 
 sub end_table_cell {
     my $self = shift;
-    my ($is_header) = validated_hash(
+    my ($is_header) = validated_list(
         \@_,
         is_header_cell => { isa => Bool },
     );


### PR DESCRIPTION
I've noticed that EndTableCell event is always rendered as th, despite is_header_cell option.