### PR TITLE
Sticky html entitites

### DIFF
--- a/lib/Markdent/Parser/SpanParser.pm
+++ b/lib/Markdent/Parser/SpanParser.pm
@@ -697,7 +697,7 @@ sub _match_html_entity {
     my $text = shift;
 
     return unless ${$text} =~ / \G
-                                &(\S+);
+                                &(\S+?);
                               /xgcs;
 
     my $event = $self->_make_event( HTMLEntity => entity => $1 );

--- a/t/markup/standard/raw-html.t
+++ b/t/markup/standard/raw-html.t
@@ -440,44 +440,45 @@ Using pair of &laquo;entities&raquo; and &THORN; and &sup2;&#37;
 EOF
 
     my $expect = [
-        { type => "paragraph" },
+        { 
+            type => "paragraph" 
+        },
         [   
-            {   text => "Using pair of ",
-                type => "text"
+            {   
+                text => "Using pair of ",
+                type => "text",
+            }, {   
+                type   => "html_entity",
+                entity => "laquo",
+            }, {   
+                type => "text",
+                text => "entities",
+            }, {   
+                entity => "raquo",
+                type   => "html_entity",
+            }, {   
+                type => "text",
+                text => " and ",
+            }, {   
+                entity => "THORN",
+                type   => "html_entity",
+            }, {   
+                type => "text",
+                text => " and ",
+            }, {   
+                entity => "sup2",
+                type   => "html_entity",
+            }, {   
+                entity => "#37",
+                type   => "html_entity",
+            }, {   
+                text => "\n",
+                type => "text",
             },
-            {   type   => "html_entity",
-                entity => "laquo"
-            },
-            {   type => "text",
-                text => "entities"
-            },
-            {   entity => "raquo",
-                type   => "html_entity"
-            },
-            {   type => "text",
-                text => " and "
-            },
-            {   entity => "THORN",
-                type   => "html_entity"
-            },
-            {   type => "text",
-                text => " and "
-            },
-            {   entity => "sup2",
-                type   => "html_entity"
-            },
-            {   entity => "#37",
-                type   => "html_entity"
-            },
-            {   text => "\n",
-                type => "text"
-            }
-        ]
+        ],
     ];
 
     parse_ok( $text, $expect, 'two wrapped html entities' );
-
-
 }
 
 done_testing();

--- a/t/markup/standard/raw-html.t
+++ b/t/markup/standard/raw-html.t
@@ -436,7 +436,7 @@ EOF
 
 {
     my $text = <<'EOF';
-Using pair of &laquo;entities&raquo; and &THORN; and &sup2;
+Using pair of &laquo;entities&raquo; and &THORN; and &sup2;&#37;
 EOF
 
     my $expect = [
@@ -464,6 +464,9 @@ EOF
                 text => " and "
             },
             {   entity => "sup2",
+                type   => "html_entity"
+            },
+            {   entity => "#37",
                 type   => "html_entity"
             },
             {   text => "\n",

--- a/t/markup/standard/raw-html.t
+++ b/t/markup/standard/raw-html.t
@@ -434,4 +434,47 @@ EOF
     parse_ok( $text, $expect, 'html comments, standalone and inline' );
 }
 
+{
+    my $text = <<'EOF';
+Using pair of &laquo;entities&raquo; and &THORN; and &sup2;
+EOF
+
+    my $expect = [
+        { type => "paragraph" },
+        [   
+            {   text => "Using pair of ",
+                type => "text"
+            },
+            {   type   => "html_entity",
+                entity => "laquo"
+            },
+            {   type => "text",
+                text => "entities"
+            },
+            {   entity => "raquo",
+                type   => "html_entity"
+            },
+            {   type => "text",
+                text => " and "
+            },
+            {   entity => "THORN",
+                type   => "html_entity"
+            },
+            {   type => "text",
+                text => " and "
+            },
+            {   entity => "sup2",
+                type   => "html_entity"
+            },
+            {   text => "\n",
+                type => "text"
+            }
+        ]
+    ];
+
+    parse_ok( $text, $expect, 'two wrapped html entities' );
+
+
+}
+
 done_testing();


### PR DESCRIPTION
Hello, it's me again.
It seems that regexp for HTML entity is too greedy.
Text ```&laquo;word&raquo;``` becomes a tree like this

```perl
$VAR1 = [
  [
    {
      "type" => "paragraph"
    },
    [
      {
        "type" => "html_entity",
        "entity" => "laquo;word&raquo"
      },
      {
        "type" => "text",
        "text" => "\n"
      }
    ]
  ]
];
```

Code sample:

```perl
use Tree::Simple::Visitor::ToNestedArray;
use Data::Dumper;
use Markdent::Parser;
use Markdent::Handler::MinimalTree;

my $visitor = Tree::Simple::Visitor::ToNestedArray->new;
my $handler = Markdent::Handler::MinimalTree->new;
 
my $parser = Markdent::Parser->new(
    handler => $handler,
);

my $markdown = "&laquo;word&raquo;";
$parser->parse( markdown => $markdown );
my $tree = $handler->tree;

$tree->accept($visitor);
my $array_tree = $visitor->getResults();

local $Data::Dumper::Indent = 1;
local $Data::Dumper::Useqq = 1;
print Dumper $array_tree;
```