### PR TITLE
Test for unicode

### DIFF
--- a/lib/Markdent/Parser/BlockParser.pm
+++ b/lib/Markdent/Parser/BlockParser.pm
@@ -7,6 +7,7 @@ use namespace::autoclean;
 our $VERSION = '0.26';
 
 use Digest::SHA1 qw( sha1_hex );
+use Encode qw/is_utf8 encode/;
 use Markdent::Event::StartDocument;
 use Markdent::Event::EndDocument;
 use Markdent::Event::StartBlockquote;
@@ -124,7 +125,7 @@ sub _hash_and_save_html {
     my $self = shift;
     my $html = shift;
 
-    my $sha1 = lc sha1_hex($html);
+    my $sha1 = lc sha1_hex(is_utf8($html) ? encode('UTF-8', $html) : $html );
 
     $self->_save_html_block( $sha1 => $html );
 

--- a/t/Parser_unicode.t
+++ b/t/Parser_unicode.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+
+use Test::Fatal;
+use Test::More 0.88;
+
+use Markdent::Dialect::Theory::BlockParser;
+use Markdent::Handler::HTMLStream::Fragment;
+use Markdent::Simple::Fragment;
+use Markdent::Parser;
+use Encode qw/encode/;
+
+use lib 't/lib';
+
+use utf8;
+
+my $parser = Markdent::Simple::Fragment->new( );
+
+my $md_unicode = <<END;
+# привет
+
+<h2>Водка медведь балалайка</h2>
+END
+
+
+{
+    no utf8;
+    my $utf8 = encode('UTF_8', $md_unicode );
+    my $html = $parser->markdown_to_html( markdown => $utf8 );
+
+    like $html, qr/привет/, 'we can use utf8'; # this fails, and chars are decoded into entities with HTML::Stream
+    diag $html;
+}
+
+{
+    my $html = $parser->markdown_to_html( markdown => $md_unicode );
+    # this fails because of sha1_hex - it can work only with bytes
+    ok $html, 'We can use unicode';
+    diag $html;
+}
+
+done_testing();


### PR DESCRIPTION
Hello,
some time ago I've found an issue with wide characters in Markdent::Parser::BlockParser.

If we have UTF-8 encoded string without UTF-8 flag, it seems to be ok, at least in Markdent itself, but HTML::Stream converts it into something ugly.
If we have UTF-8 encoded string with UTF-8 flag, we just cannot process document with HTML tags - sha1_hex fails to process wide chars.

The test here shows the case.

Are the strings with UTF-8 flag allowed here? Sorry, but I have not found anything in documentation regarding this case.
